### PR TITLE
Collapse RemovePlaywrightStyle into a single evaluate

### DIFF
--- a/src/Verify.Playwright/StyleHelper.cs
+++ b/src/Verify.Playwright/StyleHelper.cs
@@ -1,15 +1,14 @@
 ﻿static class StyleHelper
 {
-    public static async Task RemovePlaywrightStyle(this IPage page)
-    {
-        var elements = await page.QuerySelectorAllAsync("style");
-        foreach (var element in elements)
-        {
-            var value = await element.InnerHTMLAsync();
-            if (value.Contains("*:not(#playwright"))
-            {
-                await element.EvaluateAsync("element => element.remove()", element);
+    public static Task RemovePlaywrightStyle(this IPage page) =>
+        page.EvaluateAsync(
+            """
+            () => {
+                for (const style of document.querySelectorAll('style')) {
+                    if (style.innerHTML.includes('*:not(#playwright')) {
+                        style.remove();
+                    }
+                }
             }
-        }
-    }
+            """);
 }


### PR DESCRIPTION
Replace the per-style-element querySelectorAll + InnerHTML + remove round-trips with one EvaluateAsync that does the work in the browser, turning 1+N+M sequential CDP hops into a single round-trip.